### PR TITLE
Fix null image and mandatory email

### DIFF
--- a/app/User.php
+++ b/app/User.php
@@ -7,7 +7,14 @@ use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
-class User extends Authenticatable implements MustVerifyEmail, CanResetPassword
+#
+# Down the line we might want to remove the
+# the commented out implements MustVerifyEmail
+# and CanResetPassword. For making this work
+# this functionality is not essential
+#
+
+class User extends Authenticatable # implements MustVerifyEmail, CanResetPassword
 {
     use Notifiable;
     

--- a/resources/views/profile/profile.blade.php
+++ b/resources/views/profile/profile.blade.php
@@ -10,8 +10,8 @@
 
                 <div class="row text-center">
                     <div class="col-md-3 p-5">
-                        <!-- ne raboti poradi nqkakva prichina -->
-                        <img src="{{ url($user->image) }}" class="rounded-circle w-70">
+                        <!-- we don't provide image for now so it will throw exception -->
+                        {{-- <img src="{{ url($user->image) }}" class="rounded-circle w-70"> --}}
                     </div>
                     <div class="col-md-9 align-self-center">
                         <h2>{{ $user['username'] }}</h2>
@@ -25,12 +25,12 @@
                                 Edit prifile
                             </button>
                         </div>
-
-                        <div>
+                        <!-- Once we add image configuration we can uncomment this one -->
+                        <!-- <div>
                             <button type="button" class="btn mb-2 btn-primary btn-block" data-toggle="modal" data-target="#imageModal">
                                 Change picture :not_working
                             </button>
-                        </div>
+                        </div> -->
 
                         <div>
                             <button type="button" class="btn mb-2 btn-primary btn-block" data-toggle="modal" data-target="#passwordModal">


### PR DESCRIPTION
Fixing error which would not let you get into
your account as the blade requires image which
is not added in the account resultin in a null
object and preventing visits to your own profile.

Along with that removing the User class logic
which implements the MustVerifyEmail and
CanResetPassword interfaces in order to make
the smtp server non mandatory.

Signed-off-by: Martin Dekov <mvdekov@gmail.com>