### PR TITLE
Enable user segregation

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -89,6 +89,8 @@ class RegisterController extends Controller
             'password' => Hash::make($data['password']),
             'firstname' => $data['firstname'],
             'lastname' => $data['lastname'],
+            'image' => null, # Can be changed once we add logic
+            'organizer' => ($data['organizer'] == 'true' ? true : false),
         ]);
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -29,7 +29,7 @@ class User extends Authenticatable # implements MustVerifyEmail, CanResetPasswor
      * @var array
      */
     protected $fillable = [
-        'address_id', 'username', 'email', 'password', 'firstname', 'lastname', 'image',
+        'address_id', 'username', 'email', 'password', 'firstname', 'lastname', 'image', 'organizer',
     ];
 
     /**

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -17,6 +17,7 @@ class CreateUsersTable extends Migration
             $table->bigIncrements('id');
             $table->string('username')->unique();
             $table->string('email')->unique();
+            $table->boolean('organizer');
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password')->unique();
             $table->string('image')->nullable();

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -19,10 +19,10 @@
                         <div class="form-row">
                             <div class="font-weight-bold pb-1 mb-2">{{ __('Create your account') }}</div>
 
-                            <select name="role" class="custom-select mb-3" id="role" required>
+                            <select name="organizer" class="custom-select mb-3" id="organizer" required>
                                 <option value="" disabled selected hidden>Account Type</option>
-                                <option value="Client">Client</option>
-                                <option value="Organizer">Organizer</option>
+                                <option value="false">Client</option>
+                                <option value="true">Organizer</option>
                             </select>
                         </div>
 


### PR DESCRIPTION
Enabling user segregation from the registration
form which existed only as placeholder.

Migration was added to reflect whether a user
is organizer (true) or not (false means user is client)
and the form was augmented to reflect the change.

Now users can be organizers or not(clients). Tested
the change by adding two users.

Tested by creating two users:
![image](https://user-images.githubusercontent.com/34942004/71306833-2816e880-23ee-11ea-93d6-043960798a4a.png)


Signed-off-by: Martin Dekov <mvdekov@gmail.com>