### PR TITLE
Return null when there are no events

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -33,6 +33,9 @@ class EventController extends Controller
         $events = array();
             if (Auth::user()->organizer){
             $event_ids = json_decode(Auth::user()->event_organizer);
+            if ($event_ids == null){
+                return view('profile.waiting')->with('events', null);
+            }
             foreach($event_ids as $event_id){
                 $the_event = Event::all()
                 ->where('id','=',$event_id)
@@ -44,6 +47,9 @@ class EventController extends Controller
             }
         }else{
             $event_ids = json_decode(Auth::user()->event_client);
+            if ($event_ids == null){
+                return view('profile.waiting')->with('events', null);
+            }
             foreach($event_ids as $event_id){
                 $the_event = Event::all()
                 ->where('id','=',$event_id)
@@ -62,7 +68,10 @@ class EventController extends Controller
         $events = array();
             if (Auth::user()->organizer){
             $event_ids = json_decode(Auth::user()->event_organizer);
-            //return $event_ids;
+            if ($event_ids == null){
+                return view('profile.waiting')->with('events', null);
+            }
+            return $event_ids;
             foreach($event_ids as $event_id){
                 $the_event = Event::all()
                 ->where('id','=',$event_id)
@@ -74,6 +83,9 @@ class EventController extends Controller
             }
         }else{
             $event_ids = json_decode(Auth::user()->event_client);
+            if ($event_ids == null){
+                return view('profile.waiting')->with('events', null);
+            }
             foreach($event_ids as $event_id){
                 $the_event = Event::all()
                 ->where('id','=',$event_id)


### PR DESCRIPTION
Returning null when there are no event IDs since
it throw exception for supplying bad argument
for foreach as the json decode tried to
decode null object

Signed-off-by: Martin Dekov <mvdekov@gmail.com>