### PR TITLE
Separate public and private events

### DIFF
--- a/app/Event.php
+++ b/app/Event.php
@@ -11,7 +11,7 @@ class Event extends Model
     protected $table = 'events';
 
     protected $fillable = [
-        'address', 'client' , 'name', 'start_date', 'end_date' , 'description', 'organizer', 'approved',
+        'address', 'client' , 'name', 'start_date', 'end_date' , 'description', 'organizer', 'approved', 'public' ,
     ];
     
     //public function address()

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -30,7 +30,10 @@ class EventController extends Controller
 
     public function list()
     {
-        $events = Event::all()->where('approved','=',true);
+        $events = Event::all()
+        ->where('approved','=',true)
+        ->where('public','=',true);
+        
         return $events;
     }
 
@@ -128,7 +131,7 @@ class EventController extends Controller
     public function store(Request $request)
     {
         Session::flash('success', 'You have successfully created an event request please wait for response from the organizer!');
-
+        
         $event = Event::create([
             'address' =>  $request['event_address'],
             'organizer' => $request['organizer'],
@@ -136,6 +139,7 @@ class EventController extends Controller
             'end_date' => $request['end_date'],
             'client' => Auth::user()->username,
             'name' => $request['event_name'],
+            'public' => ($request['public'] == 'true' ? true : false),
             'description' => $request['event_description'],
             'approved' => false,
         ]);

--- a/database/migrations/2019_11_26_211021_create_events_table.php
+++ b/database/migrations/2019_11_26_211021_create_events_table.php
@@ -23,6 +23,7 @@ class CreateEventsTable extends Migration
             $table->string('description');
             $table->string('organizer');
             $table->boolean('approved');
+            $table->boolean('public');
             $table->timestamps();
         });
     }

--- a/resources/views/events/create.blade.php
+++ b/resources/views/events/create.blade.php
@@ -75,6 +75,14 @@
                         @endforeach
                     </select>
                 </div>
+                <div class="form-row">
+                    <div class="font-weight-bold pb-1 mb-2">{{ __('Event Type') }}</div>
+                    <select name="public" class="custom-select mb-3" id="public" required>
+                        <!-- Foreach user with organizer == true -->
+                        <option value="true">Public</option>
+                        <option value="false">Private</option>
+                    </select>
+                </div>
                 <div class="form-group row mb-3">
                     <div class="col-md-12 text-center">
                         <button type="submit" class="btn btn-lg btn-primary">

--- a/resources/views/events/show.blade.php
+++ b/resources/views/events/show.blade.php
@@ -19,7 +19,7 @@
                 <div class="border col-md-6">
                     <div class="container p-3">
                         <p>Event name: {{ $event->name }}</p>
-                        <p>Event type: </p>
+                        <p>Event type: {{ $event->public ? "Public" : "Private"}}</p>
                         <p>Organizer: {{ $event->organizer }}</p>
                         <p>Date: {{ date( 'F j, Y, H:i', strtotime($event->start_date)) }} </p>
                         <p>Number of people: </p>

--- a/resources/views/profile/approved.blade.php
+++ b/resources/views/profile/approved.blade.php
@@ -7,14 +7,19 @@
         </div>
         @else
         @foreach ($events as $event)  
-        <div class="jumbotron">
+            <div class="jumbotron">
                 <div class="container">
-                    <h1 class="display-4">{{$event->name}}</h1>
+                <h1 class="display-4">{{$event->name}}</h1>
                     <p class="lead">{{$event->description}}</p>
                     <p> {{$event->start_date}} </p>
                     <p> {{$event->end_date}}  </p>
-                </div> 
-        </div>
+                    <div class="btn-toolbar mb-3" role="toolbar">
+                        <div class="btn-group mr-4" role="group">
+                            <a href="{{url("/events/show/$event->id")}}"><button type="button" class="btn btn-primary">View</button></a>
+                        </div> 
+                    </div> 
+                </div>
+            </div>
         @endforeach
         @endif
     </div>

--- a/resources/views/profile/waiting.blade.php
+++ b/resources/views/profile/waiting.blade.php
@@ -13,11 +13,16 @@
                         <p class="lead">{{$event->description}}</p>
                         <p> {{$event->start_date}} </p>
                         <p> {{$event->end_date}}  </p> 
-                        @if (Auth::user()->organizer)
-                            <p class="lead">
-                                <a class="btn btn-primary btn-lg" href="{{ route('event.approve', $event->id)}}" role="button">Approve</a>
-                            </p>
-                        @endif
+                        <div class="btn-toolbar mb-3" role="toolbar">
+                            <div class="btn-group mr-4" role="group">
+                                <a href="{{url("/events/show/$event->id")}}"><button type="button" class="btn btn-primary">View</button></a>
+                            </div>  
+                            @if (Auth::user()->organizer)
+                                <div class="btn-group mr-4" role="group"> 
+                                    <a href="{{ route('event.approve', $event->id)}}"><button type="button" class="btn btn-primary">Approve</button></a>
+                                </div> 
+                            @endif
+                        </div>
                 </div> 
             </div>
         @endforeach


### PR DESCRIPTION
Adding logic which will separate events based
on dropdown in the create event section. Now
you can view events from your profile's approved
or waiting for approval section. Only the public
events will be rendered on the calendar

Signed-off-by: Martin Dekov <mvdekov@gmail.com>