### PR TITLE
Add final touches to images and comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /node_modules
 /public/hot
-/public/storage
-/storage/*.key
+/public/storage/*.jpg
+/public/storage/*.png
 /vendor
 .env
 .env.backup

--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -129,6 +129,9 @@ class EventController extends Controller
         //Post event picture
         if ($request->has('add_image')) {
             $image_path = $request->file('event_image');
+            if($image_path == null){
+                return back()->with('error', "You haven't specified an Image!");
+            }
             $filename = time() . "." . $image_path->getClientOriginalExtension();
             Image::make($image_path)->save(public_path('storage/' . $filename));
             //$event->eventImages()->event_image = $filename;

--- a/public/storage/README.md
+++ b/public/storage/README.md
@@ -1,0 +1,1 @@
+# Folder for storing images

--- a/resources/views/events/show.blade.php
+++ b/resources/views/events/show.blade.php
@@ -28,17 +28,21 @@
                             <p class="m-0 m-3">Description: {{ $event->description }} </p>
                     </div>
                 </div>
-                @forelse($event->eventImages as $eventImage)
-                <img class="rounded-circle" src="{{ asset('storage/'.$eventImage->event_image) }}" style="width:100px; height:100px;" alt="event picture">
-                @empty
-                <div class="row card shadow-lg bg-white mt-2">
-                    <div class="card-body text-center">
-                        <div class="card-title pt-2 mb-2">
-                            <h3>This event has no pictures yet!</h3>
+                @if (!empty($event->eventImages))
+                    <div class="row card shadow-lg d-flex flex-row bd-highlight bg-white mt-2">
+                        @foreach($event->eventImages as $eventImage)
+                            <img class="rounded-circle m-3" src="{{ asset('storage/'.$eventImage->event_image) }}" style="width:100px; height:100px;" alt="event picture">
+                        @endforeach
+                    </div>
+                @else
+                    <div class="row card shadow-lg bg-white mt-2">
+                        <div class="card-body text-center">
+                            <div class="card-title pt-2 mb-2">
+                                <h3>This event has no pictures yet!</h3>
+                            </div>
                         </div>
                     </div>
-                </div>
-                @endforelse
+                @endif
                 <form class="row" role="form" method="POST" action="{{ route('event_view.store', $event->id ) }}" enctype="multipart/form-data" autocomplete="off">
                         @method('POST')
                         @csrf
@@ -55,11 +59,14 @@
                         @csrf
 
                         <div class="input-group d-flex">
-                            <div class="input-group-prepend">
+                            <div class="d-flex flex-row bd-highlight">
                                 <img class="rounded-circle" src="{{ asset(auth()->user()->image) }}" style="width:50px; height:50px;" alt="profile picture">
                             </div>
-                            <input type="text" class="form-control ml-1 mt-2" name="comment" placeholder="Write a comment...">
-                            <div class="btn-group pt-1 pb-1" role="group" aria-label="Basic example">
+                            <div class="flex-grow-1 bd-highlight">
+                                    <input type="text" class="form-control ml-1 mt-2" name="comment" placeholder="Write a comment...">
+                            </div>
+                            
+                            <div class="btn-group m-2" role="group" aria-label="Basic example">
                                 <button class="btn btn-primary ml-1" id="add_comment" name="add_comment" type="submit">Comment</button>
                             </div>
                         </div>


### PR DESCRIPTION
Adding final touches to images and comments milestone.
If image is not specified error will be returned instead
throwing an exception. Added flexbox for the images div in
order to go wrap on the next row when space ends. Added empty
storage folder with readme so you don't have an exception
telling you folder like that does not exist.

Signed-off-by: Martin Dekov <mvdekov@gmail.com>

Flexbox image rows:
![image](https://user-images.githubusercontent.com/34942004/73100051-72abe900-3ef5-11ea-9af5-17e022d84d21.png)

When you specified no image path:
![image](https://user-images.githubusercontent.com/34942004/73100147-a71fa500-3ef5-11ea-8915-16fe89e273ba.png)

When only one row of images:
![image](https://user-images.githubusercontent.com/34942004/73100440-3a58da80-3ef6-11ea-997b-64d787f3a9f8.png)

Closes #10 